### PR TITLE
Deep sort

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deep_sort"]
+	path = deep_sort
+	url = https://github.com/nwojke/deep_sort.git

--- a/ava_conf.yaml
+++ b/ava_conf.yaml
@@ -68,15 +68,15 @@ RNG_SEED: 0
 OUTPUT_DIR: .
 DEMO:
   DETECTRON2_THRESH: 0.75
-  #DETECTRON2_CFG: COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml
-  #DETECTRON2_WEIGHTS: detectron2://COCO-Detection/faster_rcnn_R_50_FPN_3x/137849458/model_final_280758.pkl
-  DETECTRON2_CFG: COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml
-  DETECTRON2_WEIGHTS: detectron2://COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x/139173657/model_final_68b088.pkl
+  DETECTRON2_CFG: COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml
+  DETECTRON2_WEIGHTS: detectron2://COCO-Detection/faster_rcnn_R_50_FPN_3x/137849458/model_final_280758.pkl
+  #DETECTRON2_CFG: COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x.yaml
+  #DETECTRON2_WEIGHTS: detectron2://COCO-Detection/faster_rcnn_X_101_32x8d_FPN_3x/139173657/model_final_68b088.pkl
   ENABLE: True
   THREAD_ENABLE: False
   OUTPUT_FILE: test_output.mp4
   LABEL_FILE_PATH: "SlowFast/ava_classnames.json"
-  INPUT_VIDEO: test.mp4  # Path to a video file or image folder
+  INPUT_VIDEO: ur.mp4  # Path to a video file or image folder
   COMMON_CLASS_NAMES: [
     "watch (a person)",
     "talk to",


### PR DESCRIPTION
Enable deep sort with a faster detectron2 detection rate

TODO:
 - [x] Use detectron2 between slowfast predictions to have more regular bounding boxes updates
 - [ ] Skip frames for detectron2 to speed up the process
 - [ ] Use deep sort to track the boxes
 - [ ] Remove the previous tracker ?